### PR TITLE
fix: Handle schema composition better (but not perfectly)

### DIFF
--- a/lib/schema-object.js
+++ b/lib/schema-object.js
@@ -197,7 +197,7 @@ class SchemaObject {
         // Only process items that can actually be seriailised i.e a named schema object
         if (child.value.type && !isKeywordExtensionOrIndex(child.path.slice(-1).pop())) {
           const { path } = this.schemaObject;
-          const [,, url, method, , contentPath] = path || [];
+          const [, , url, method, , contentPath] = path || [];
           const pathOrSchemaObjectName = url || this.schemaObjectName;
           // eslint-disable-next-line no-nested-ternary
           const returnCode = !contentPath ? '' : (contentPath === 'content' ? 'Request Body' : contentPath);
@@ -263,11 +263,19 @@ class SchemaObject {
             `${dereferencedSchemaPath}.items`,
           ];
 
+          const schemaComposition = value.oneOf || value.allOf || value.anyOf;
+          const { discriminator } = value;
+
+          if (!schemaComposition && !value.type) {
+            console.error(value);
+            throw new Error('Not imeplemented');
+          }
+
           // Catch-all loop over additional requirements
           const additionalRequirements = (
             value.type
               ? [value] // Has a type set
-              : Object.values(value).pop()) // Has a composition keyword set
+              : schemaComposition) // Has a composition keyword set
             .map((additionaPropertyValue) => {
               const additionalRequirementFn = getTypeFunction(additionaPropertyValue.type, additionaPropertyValue, 'additional');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-stuff/master-exploder",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Summary of changes:

* Destructure schema composition keyword rather than popping it from `Object.values`.
* Throw an error if `type` property or schema composition keyword not found

🦉 